### PR TITLE
Do not install TCIB in base image

### DIFF
--- a/containers/openstack-base/Containerfile
+++ b/containers/openstack-base/Containerfile
@@ -7,10 +7,8 @@ USER root
 RUN if [ -f "/etc/yum.repos.d/ubi.repo" ]; then rm -f /etc/yum.repos.d/ubi.repo && dnf clean all && rm -rf /var/cache/dnf; fi
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256 /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512 && dnf install -y centos-release-cloud && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
 RUN dnf install -y crudini && crudini --del /etc/dnf/dnf.conf main override_install_langs && crudini --set /etc/dnf/dnf.conf main clean_requirements_on_remove True && crudini --set /etc/dnf/dnf.conf main exactarch 1 && crudini --set /etc/dnf/dnf.conf main gpgcheck 1 && crudini --set /etc/dnf/dnf.conf main install_weak_deps False && if [ 'centos' == 'centos' ];then crudini --set /etc/dnf/dnf.conf main best False; fi && crudini --set /etc/dnf/dnf.conf main installonly_limit 0 && crudini --set /etc/dnf/dnf.conf main keepcache 0 && crudini --set /etc/dnf/dnf.conf main obsoletes 1 && crudini --set /etc/dnf/dnf.conf main plugins 1 && crudini --set /etc/dnf/dnf.conf main skip_missing_names_on_install False && crudini --set /etc/dnf/dnf.conf main tsflags nodocs
-RUN dnf install -y ca-certificates dumb-init glibc-langpack-en procps-ng python3 python3-pip python3-setuptools python3-wheel sudo util-linux-user which gcc python3-devel git-core libffi-devel openssl-devel rust cargo
+RUN dnf install -y ca-certificates dumb-init glibc-langpack-en procps-ng python3 sudo util-linux-user which
 COPY . /workspace
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
-RUN pip install --verbose --no-cache-dir /workspace/containers/openstack-base/tcib
 RUN cp /workspace/containers/openstack-base/tcib/container-images/kolla/base/uid_gid_manage.sh /usr/local/bin/uid_gid_manage
 RUN chmod 755 /usr/local/bin/uid_gid_manage
 RUN bash /usr/local/bin/uid_gid_manage kolla hugetlbfs libvirt qemu


### PR DESCRIPTION
We don't need to install TCIB module in base image as we only want the data (kolla base scripts [1]). We are copying them from repo directly.

[1] https://github.com/openstack-k8s-operators/tcib/tree/main/container-images/kolla/base